### PR TITLE
Automate and enable contributors to self assign issues

### DIFF
--- a/.github/workflows/PULL_REQUEST_TEMPLATE.md
+++ b/.github/workflows/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,83 @@
+<!--
+  For Work In Progress Pull Requests, please use the Draft PR feature,
+  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
+  
+  For a timely review/response, please avoid force-pushing additional
+  commits if your PR already received reviews or comments.
+  
+  Before submitting a Pull Request, please ensure you've done the following:
+  - 📖 Read the TBD Developer Website Contributing Guide: https://github.com/TBD54566975/developer.tbd.website/blob/main/CONTRIBUTING.md.
+  - 📖 Read the TBD Developer Website Code of Conduct: https://github.com/TBD54566975/developer.tbd.website/blob/main/CODE_OF_CONDUCT.md.
+  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
+  - ✅ Provide tests for your changes.
+  - 📝 Use descriptive commit messages.
+  - 📗 Update any related documentation and include any relevant screenshots.
+-->
+
+## What type of PR is this? (check all applicable)
+
+- [ ] ♻️ Refactor
+- [ ] ✨ New Feature
+- [ ] 🐛 Bug Fix
+- [ ] 📝 Documentation Update
+- [ ] 👷 Example Application
+- [ ] 🧑‍💻 Code Snippet
+- [ ] 🎨 Design
+- [ ] 📖 Content
+- [ ] 🧪 Tests
+- [ ] 🔖 Release
+- [ ] 🚩 Other
+
+## Description
+
+<!-- Please do not leave this blank -->
+
+This PR [adds/removes/fixes/replaces] this [feature/bug/etc]. 
+
+## Related Tickets & Documents
+<!-- 
+Please use this format link issue numbers: Resolves #123
+https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
+-->
+Resolves #
+
+## Mobile & Desktop Screenshots/Recordings
+
+<!-- Visual changes require screenshots -->
+
+## Added code snippets?
+- [ ] 👍 yes
+- [ ] 🙅 no, because they aren't needed
+
+## Added tests?
+
+- [ ] 👍 yes
+- [ ] 🙅 no, because they aren't needed
+- [ ] 🙋 no, because I need help
+
+### No tests? Add a note
+<!-- 
+If you didn't provide tests with this PR, please explain here why they aren't needed.
+-->
+
+## Added to documentation?
+
+- [ ] 📜 readme
+- [ ] 📜 contributing.md
+- [ ] 📓 general documentation
+- [ ] 🙅 no documentation needed
+
+### No docs? Add a note
+<!-- 
+If you didn't provide documentation with this PR, please explain here why it's not needed.
+-->
+
+## [optional] Are there any post-deployment tasks we need to perform?
+
+
+
+## [optional] What gif best describes this PR or how it makes you feel?
+
+
+
+<!-- note: PRs with deletes sections will be marked invalid -->

--- a/.github/workflows/take.yml
+++ b/.github/workflows/take.yml
@@ -1,0 +1,34 @@
+name: Auto-assign issue to contributor
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  assign:
+    name: Take an issue
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Check if it's October
+        id: check-month
+        run: |
+          current_month=$(date -u +%m)
+          if [[ $current_month == "10" ]]; then
+            echo "is_october=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_october=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Take the issue
+        if: steps.check-month.outputs.is_october == 'true'
+        uses: bdougie/take-action@1439165ac45a7461c2d89a59952cd7d941964b87
+        with:
+          message: Thanks for taking this issue! Let us know if you have any questions!
+          trigger: .take
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log when outside October
+        if: steps.check-month.outputs.is_october == 'false'
+        run: echo "Action skipped because the current date is not in October."


### PR DESCRIPTION
Contributors can use the keyword .take to assign themselves issues and the maintainer doesn't have to be a middleman